### PR TITLE
Test packaging in CI test flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,11 @@ jobs:
       run: |
         make test
 
+    - name: Test packaging
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     keywords='rdf, application profile, data shape, statistics, fingerprint, sparql, linked-data',
     packages=packages,
     # exclude=["tests", "test_*"],
-    license='Apache License 2.0'
+    license='Apache License 2.0',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python",


### PR DESCRIPTION
Add a CI test step for testing packaging commands

So that we don't get surprises on the actual publication.