### PR TITLE
Fix Python version requirement, old references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RDF fingerprinter may be installed with pip as follows.
 ```
 pip install rdf-fingerprinter
 ```
-Nore that Python version 3.7 or later is required.  
+Note that Python version 3.8 or later is required.
 
 # Usage
 

--- a/fingerprint/__init__.py
+++ b/fingerprint/__init__.py
@@ -9,7 +9,7 @@ import logging.config
 
 __docformat__ = "restructuredtext en"
 
-__version__ = "0.3.0"
-__date__ = "2023-10-20"
+__version__ = "0.3.1"
+__date__ = "2024-02-01"
 
 logging.config.fileConfig('logging.conf')

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Natural Language :: English",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     entry_points={
         "console_scripts": ["fingerprint=fingerprint.entrypoints.cli.main:fingerprint_endpoint"]
     }


### PR DESCRIPTION
This requires either a new release or recreation of release and PyPi distribution, as there is a possibility that dependency resolution may be affected.